### PR TITLE
From nullable projection ending on not null type we can now map to nullable type.

### DIFF
--- a/UltraMapper.Tests/Projections/ProjectionNotNullToNull.cs
+++ b/UltraMapper.Tests/Projections/ProjectionNotNullToNull.cs
@@ -12,7 +12,7 @@ namespace UltraMapper.Tests.Projections
             var mapper = new Mapper( cfg =>
             {
                 cfg.MapTypes<A, D>()
-                 .MapMember( a => a.BProp.CProp.Id, d => d.NullableId );
+                 .MapMemberNullProjection( a => a.BProp.CProp.Id, d => d.NullableId );
             } );
 
             var aObject = new A
@@ -30,7 +30,7 @@ namespace UltraMapper.Tests.Projections
             var mapper = new Mapper( cfg =>
             {
                 cfg.MapTypes<A, D>()
-                 .MapMember( a => a.BProp.CProp.Id, d => d.NullableId );
+                 .MapMemberNullProjection( a => a.BProp.CProp.Id, d => d.NullableId );
             } );
 
             var aObject = new A
@@ -48,7 +48,7 @@ namespace UltraMapper.Tests.Projections
             var mapper = new Mapper( cfg =>
             {
                 cfg.MapTypes<A, D>()
-                 .MapMember( a => a.BProp.CProp.Id, d => d.NullableId );
+                 .MapMemberNullProjection( a => a.BProp.CProp.Id, d => d.NullableId );
             } );
             var aObject = new A
             {
@@ -64,7 +64,7 @@ namespace UltraMapper.Tests.Projections
             var mapper = new Mapper( cfg =>
             {
                 cfg.MapTypes<A, D>()
-                 .MapMember( a => a.BProp.CProp.Id, d => d.NullableId );
+                 .MapMemberNullProjection( a => a.BProp.CProp.Id, d => d.NullableId );
             } );
 
             var aObject = new A

--- a/UltraMapper.Tests/RealworldBugs/RealworldBug3.cs
+++ b/UltraMapper.Tests/RealworldBugs/RealworldBug3.cs
@@ -57,8 +57,8 @@ namespace UltraMapper.Tests.RealworldBugs
             var mapper = new Mapper( cfg =>
             {
                 cfg.MapTypes<A, D>()
-                 .MapMember( a => a.BProp.Id, d => d.B_Id )
-                 .MapMember( a => a.CProp.Id, d => d.C_Id );
+                 .MapMemberNullProjection( a => a.BProp.Id, d => d.B_Id )
+                 .MapMemberNullProjection( a => a.CProp.Id, d => d.C_Id );
             } );
 
             var aObject = new A

--- a/UltraMapper/Configuration/Mapping/MappingPoints/MappingSource/StructMappingSource.cs
+++ b/UltraMapper/Configuration/Mapping/MappingPoints/MappingSource/StructMappingSource.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace UltraMapper.Internals
+{
+    public class StructMappingSource : IMappingSource
+    {
+        private readonly MemberAccessPath _sourcePath;
+        private readonly MemberInfo _memberInfo;
+        private string _toString;
+        private LambdaExpression _valueGetter;
+
+        public StructMappingSource( MemberAccessPath sourcePath, LambdaExpression sourceMemberGetterExpression )
+        {
+            _sourcePath = sourcePath;
+            _memberInfo = sourcePath.Last();
+            var originalReturnType = sourcePath.ReturnType;
+            ReturnType = GetNullableType( originalReturnType );
+            _valueGetter = sourcePath.GetNullableGetterExpWithNullChecks();
+        }
+
+        public LambdaExpression ValueGetter => _valueGetter;
+
+        public Type EntryType => _sourcePath.EntryInstance;
+
+        public Type ReturnType { get; private set; }
+
+        public Type MemberType => ReturnType;
+
+        public MemberAccessPath MemberAccessPath => _sourcePath;
+
+        public bool Ignore { get; set; }
+
+        public override bool Equals( object obj )
+        {
+            if( obj is StructMappingSource mp )
+            {
+                return _memberInfo.Equals( mp._memberInfo ) &&
+                    this.MemberAccessPath.EntryInstance.Equals( mp.MemberAccessPath.EntryInstance ) &&
+                    this.MemberAccessPath.ReturnType.Equals( mp.MemberAccessPath.ReturnType );
+            }
+
+            return false;
+        }
+
+        public override int GetHashCode()
+        {
+            return _memberInfo.GetHashCode() ^
+                this.MemberAccessPath.EntryInstance?.GetHashCode() ?? 0 ^
+                this.MemberAccessPath.ReturnType?.GetHashCode() ?? 0;
+        }
+
+        public override string ToString()
+        {
+            if( _toString == null )
+            {
+                string typeName = this.MemberType.GetPrettifiedName();
+                _toString = this._sourcePath.Last() == this.MemberType ? typeName
+                    : $"{typeName} {this._sourcePath.Last().Name}";
+            }
+
+            return _toString;
+        }
+
+        private Type GetNullableType( Type notNullableType )
+        {
+            var type = Nullable.GetUnderlyingType( notNullableType ) ?? notNullableType; // avoid type becoming null
+            if( type.IsValueType )
+                return typeof( Nullable<> ).MakeGenericType( type );
+            else
+                return type;
+        }
+    }
+}

--- a/UltraMapper/Configuration/Mapping/TypeMapping.cs
+++ b/UltraMapper/Configuration/Mapping/TypeMapping.cs
@@ -219,6 +219,18 @@ namespace UltraMapper.Internals
                } );
         }
 
+        public IMappingSource GetNullStructMappingSource( MemberAccessPath sourcePath, LambdaExpression sourceMemberGetterExpression )
+        {
+            var sourceMember = sourcePath.Last();
+            return _sources.GetOrAdd( sourceMember,
+                  () =>
+                  {
+                      var mp = new StructMappingSource( sourcePath, sourceMemberGetterExpression );
+                      var isAdded = _mappingSource.Add( mp );
+                      return mp;
+                  } );
+        }
+
         public IMappingTarget GetMappingTarget( MemberInfo targetMember,
             MemberAccessPath targetMemberPath )
         {


### PR DESCRIPTION
When the resulting type from a projection is not nullable but earlier in the projection chain we can have a null.
This method allows us to map to a nullable type and then have null there.

And make this be able to project to a nullable type and have null there instead of 0.