### PR TITLE
Adding configuration profiles to automapper.

### DIFF
--- a/DI_ConsoleApp_ProfileInjection/ClassesToMap/Company/CompanyMappingProfile.cs
+++ b/DI_ConsoleApp_ProfileInjection/ClassesToMap/Company/CompanyMappingProfile.cs
@@ -1,0 +1,26 @@
+﻿using UltraMapper;
+using UltraMapper.ConfigurationProfiles;
+
+namespace DI_ConsoleApp_ProfileInjection.ClassesToMap.Company
+{
+    public class CompanyMappingProfile : IMappingProfile
+    {
+        public void Configure( Configuration config )
+        {
+            config.MapTypes<FromCompany, ToCompany>()
+                .MapMember( x => x.CompanyName, y => y.Name )
+                .MapMember( x => x.CompanyType, y => y.CompanyType, x => MapCompanyType( x ) );
+        }
+
+        public string MapCompanyType( int type )
+        {
+            switch( type )
+            {
+                case 1: return "Right company type";
+                case 2: return "My other type";
+            }
+            return "Unknown type";
+        }
+
+    }
+}

--- a/DI_ConsoleApp_ProfileInjection/ClassesToMap/Company/FromCompany.cs
+++ b/DI_ConsoleApp_ProfileInjection/ClassesToMap/Company/FromCompany.cs
@@ -1,0 +1,9 @@
+﻿namespace DI_ConsoleApp_ProfileInjection.ClassesToMap.Company
+{
+    public class FromCompany
+    {
+        public string CompanyName { get; set; }
+        public int CompanyType { get; set; }
+
+    }
+}

--- a/DI_ConsoleApp_ProfileInjection/ClassesToMap/Company/ToCompany.cs
+++ b/DI_ConsoleApp_ProfileInjection/ClassesToMap/Company/ToCompany.cs
@@ -1,0 +1,9 @@
+﻿namespace DI_ConsoleApp_ProfileInjection.ClassesToMap.Company
+{
+    public class ToCompany
+    {
+        public string Name { get; set; }
+
+        public string CompanyType { get; set; }
+    }
+}

--- a/DI_ConsoleApp_ProfileInjection/ClassesToMap/ConvertedFrom.cs
+++ b/DI_ConsoleApp_ProfileInjection/ClassesToMap/ConvertedFrom.cs
@@ -1,0 +1,11 @@
+﻿using DI_ConsoleApp_ProfileInjection.ClassesToMap.Company;
+using DI_ConsoleApp_ProfileInjection.ClassesToMap.User;
+
+namespace DI_ConsoleApp_ProfileInjection.ClassesToMap
+{
+    public class ConvertedFrom
+    {
+        public FromUser User { get; set; }
+        public FromCompany Company { get; set; }   
+    }
+}

--- a/DI_ConsoleApp_ProfileInjection/ClassesToMap/ConvertedTo.cs
+++ b/DI_ConsoleApp_ProfileInjection/ClassesToMap/ConvertedTo.cs
@@ -1,0 +1,11 @@
+﻿using DI_ConsoleApp_ProfileInjection.ClassesToMap.Company;
+using DI_ConsoleApp_ProfileInjection.ClassesToMap.User;
+
+namespace DI_ConsoleApp_ProfileInjection.ClassesToMap
+{
+    public class ConvertedTo
+    {
+        public ToUser User_MapTo { get; set; }   
+        public ToCompany Company_MapTo { get; set; } 
+    }
+}

--- a/DI_ConsoleApp_ProfileInjection/ClassesToMap/MainMappingProfile.cs
+++ b/DI_ConsoleApp_ProfileInjection/ClassesToMap/MainMappingProfile.cs
@@ -1,0 +1,15 @@
+﻿using UltraMapper;
+using UltraMapper.ConfigurationProfiles;
+
+namespace DI_ConsoleApp_ProfileInjection.ClassesToMap
+{
+    public class MainMappingProfile : IMappingProfile
+    {
+        public void Configure( Configuration config )
+        {
+            config.MapTypes<ConvertedFrom, ConvertedTo>()
+                .MapMember( x => x.User, y => y.User_MapTo )
+                .MapMember( x => x.Company, y => y.Company_MapTo );
+        }
+    }
+}

--- a/DI_ConsoleApp_ProfileInjection/ClassesToMap/User/FromUser.cs
+++ b/DI_ConsoleApp_ProfileInjection/ClassesToMap/User/FromUser.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace DI_ConsoleApp_ProfileInjection.ClassesToMap.User
+{
+    public class FromUser
+    {
+        public string Name { get; set; }
+        public long MyId { get; set; }
+    }
+}

--- a/DI_ConsoleApp_ProfileInjection/ClassesToMap/User/ToUser.cs
+++ b/DI_ConsoleApp_ProfileInjection/ClassesToMap/User/ToUser.cs
@@ -1,0 +1,9 @@
+﻿namespace DI_ConsoleApp_ProfileInjection.ClassesToMap.User
+{
+    public class ToUser
+    {
+        public string UserName { get; set; }
+
+        public string Id { get; set; }
+    }
+}

--- a/DI_ConsoleApp_ProfileInjection/ClassesToMap/User/UserMappingProfile.cs
+++ b/DI_ConsoleApp_ProfileInjection/ClassesToMap/User/UserMappingProfile.cs
@@ -1,0 +1,15 @@
+﻿using UltraMapper;
+using UltraMapper.ConfigurationProfiles;
+
+namespace DI_ConsoleApp_ProfileInjection.ClassesToMap.User
+{
+    public class UserMappingProfile : IMappingProfile
+    {
+        public void Configure( Configuration config )
+        {
+            config.MapTypes<FromUser, ToUser>()
+                .MapMember( x => x.Name, y => y.UserName )
+                .MapMember( x => x.MyId, y => y.Id, s => s.ToString() );
+        }
+    }
+}

--- a/DI_ConsoleApp_ProfileInjection/DI_ConsoleApp_ProfileInjection.csproj
+++ b/DI_ConsoleApp_ProfileInjection/DI_ConsoleApp_ProfileInjection.csproj
@@ -1,0 +1,18 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net6.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\UltraMapper\UltraMapper.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/DI_ConsoleApp_ProfileInjection/Extensions/UltramapperExtension.cs
+++ b/DI_ConsoleApp_ProfileInjection/Extensions/UltramapperExtension.cs
@@ -1,0 +1,36 @@
+﻿using Microsoft.Extensions.DependencyInjection;
+using System.Reflection;
+using UltraMapper.ConfigurationProfiles;
+
+namespace DI_ConsoleApp_ProfileInjection.Extensions
+{
+    public static class UltramapperExtension
+    {
+        public static IServiceCollection AddSingletonUltraMapper( this IServiceCollection services, params Assembly[] assemblies )
+        {
+            return RegisterMappingProfiles( services, assemblies ).AddSingletonUltraMapper();
+        }
+
+        public static IServiceCollection AddSingletonUltraMapper( this IServiceCollection services )
+        {
+            return services.AddSingleton( sp =>
+            {
+                var profiles = sp.GetServices<IMappingProfile>();
+                return MappingConfigExtensions.CreateProfileBasedMapper( profiles );
+            } );
+        }
+
+        private static IServiceCollection RegisterMappingProfiles( IServiceCollection services, Assembly[] assemblies )
+        {
+            var interfaceType = typeof( IMappingProfile );
+            var types = assemblies
+                .SelectMany( s => s.GetTypes() )
+                .Where( p => interfaceType.IsAssignableFrom( p ) );
+            foreach( var type in types )
+            {
+                services = services.AddTransient( interfaceType, type );
+            }
+            return services;
+        }
+    }
+}

--- a/DI_ConsoleApp_ProfileInjection/MyApplication.cs
+++ b/DI_ConsoleApp_ProfileInjection/MyApplication.cs
@@ -1,0 +1,20 @@
+﻿using DI_ConsoleApp_ProfileInjection.ClassesToMap;
+using UltraMapper;
+
+namespace DI_ConsoleApp_ProfileInjection
+{
+    public class MyApplication
+    {
+        private readonly Mapper _ultramapper;
+
+        public MyApplication(Mapper ultramapper )
+        {
+            _ultramapper = ultramapper;
+        }
+
+        public ConvertedTo ConvertEntry(ConvertedFrom before )
+        {
+            return _ultramapper.Map<ConvertedTo>( before );
+        }
+    }
+}

--- a/DI_ConsoleApp_ProfileInjection/Program.cs
+++ b/DI_ConsoleApp_ProfileInjection/Program.cs
@@ -1,0 +1,24 @@
+﻿using DI_ConsoleApp_ProfileInjection;
+using DI_ConsoleApp_ProfileInjection.ClassesToMap;
+using DI_ConsoleApp_ProfileInjection.ClassesToMap.Company;
+using DI_ConsoleApp_ProfileInjection.ClassesToMap.User;
+using DI_ConsoleApp_ProfileInjection.Extensions;
+using Microsoft.Extensions.DependencyInjection;
+// Create the service container
+var builder = new ServiceCollection()
+    .AddSingleton<MyApplication>()
+    .AddSingletonUltraMapper( typeof( Program ).Assembly )
+    .BuildServiceProvider();
+var app = builder.GetRequiredService<MyApplication>();
+
+ConvertedFrom from = new ConvertedFrom
+{
+    User = new FromUser { MyId = 45, Name = "Its me" },
+    Company = new FromCompany { CompanyType = 2, CompanyName = "MyCompany" }
+};
+var mapped = app.ConvertEntry( from );
+
+Console.WriteLine( $"UserName {mapped.User_MapTo.UserName}" );
+Console.WriteLine( $"UserId {mapped.User_MapTo.Id}" );
+Console.WriteLine( $"CompanyName {mapped.Company_MapTo.Name}" );
+Console.WriteLine( $"CompanyType {mapped.Company_MapTo.CompanyType}" );

--- a/UltraMapper.sln
+++ b/UltraMapper.sln
@@ -14,6 +14,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UltraMapper.Tests", "UltraM
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "UltraMapper.Benchmarks", "UltraMapper.Benchmarks\UltraMapper.Benchmarks.csproj", "{A8B2252F-B9C2-4B4D-BD33-D640763F753E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DI_ConsoleApp_ProfileInjection", "DI_ConsoleApp_ProfileInjection\DI_ConsoleApp_ProfileInjection.csproj", "{155A71DD-4B89-4084-B49B-31AE4D01A8C6}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -32,6 +34,10 @@ Global
 		{A8B2252F-B9C2-4B4D-BD33-D640763F753E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{A8B2252F-B9C2-4B4D-BD33-D640763F753E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{A8B2252F-B9C2-4B4D-BD33-D640763F753E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{155A71DD-4B89-4084-B49B-31AE4D01A8C6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{155A71DD-4B89-4084-B49B-31AE4D01A8C6}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{155A71DD-4B89-4084-B49B-31AE4D01A8C6}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{155A71DD-4B89-4084-B49B-31AE4D01A8C6}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/UltraMapper/ConfigurationProfiles/IMappingProfile.cs
+++ b/UltraMapper/ConfigurationProfiles/IMappingProfile.cs
@@ -1,0 +1,7 @@
+﻿namespace UltraMapper.ConfigurationProfiles
+{
+    public interface IMappingProfile
+    {
+        void Configure( Configuration config );
+    }
+}

--- a/UltraMapper/ConfigurationProfiles/MappingConfigExtensions.cs
+++ b/UltraMapper/ConfigurationProfiles/MappingConfigExtensions.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace UltraMapper.ConfigurationProfiles
+{
+    public static class MappingConfigExtensions
+    {
+        public static Mapper CreateProfileBasedMapper(IEnumerable<IMappingProfile> profiles)
+        {
+            Action<Configuration> action = ( config ) => {
+                foreach ( var profile in profiles )
+                {
+                    profile.Configure(config);
+                }
+            };
+            var mapper = new Mapper( action );
+            return mapper;
+        } 
+    }
+}


### PR DESCRIPTION
To not have a huge mapper class with way too many dependencies
 (Which tools like Sonarcloud do whine about) for configuring Ultramapper.  Now we have the possibility to use multiple separate Mapping profiles that together build the mapper configuration. 